### PR TITLE
Remove py2 from wheel, switch to static metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+[metadata]
+name = netflix-spectator-py-runtime-metrics
+version = 1.0.0rc0
+description = Library to collect runtime metrics for Python applications using spectator-py.
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Netflix Telemetry Engineering
+author_email = netflix-atlas@googlegroups.com
+license = Apache 2.0
+url = https://github.com/Netflix/spectator-py-runtime-metrics
+
+[options]
+python_requires = >3.9
+packages =
+    runmetrics
+install_requires =
+    netflix-spectator-py==1.0.0rc1
+
+[options.extras_require]
+dev =
+  check-manifest
+  pylint
+  pytest-cov
+  pytest
+

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,3 @@
-import os
-
 from setuptools import setup
 
-
-def read(fname):
-    """Utility function to read a file, for publishing the README with the package."""
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-
-setup(
-    name="netflix-spectator-py-runtime-metrics",
-    version="1.0.0rc0",
-    python_requires=">3.9",
-    description="Library to collect runtime metrics for Python applications using spectator-py.",
-    long_description=read("README.md"),
-    long_description_content_type="text/markdown",
-    author="Netflix Telemetry Engineering",
-    author_email="netflix-atlas@googlegroups.com",
-    license="Apache 2.0",
-    url="https://github.com/Netflix/spectator-py-runtime-metrics",
-    packages=["runmetrics"],
-    install_requires=["netflix-spectator-py==1.0.0rc1"],
-    extras_require={
-        "dev": [
-            "check-manifest",
-            "pylint",
-            "pytest-cov",
-            "pytest"
-        ]
-    }
-)
+setup()


### PR DESCRIPTION
The setuptools metadata isn't as standardized as pep 621 metadata would be, but this allows extracting (e.g. in [dowsing](https://github.com/python-packaging/dowsing)) without executing the .py

Please verify no unwanted changes in the dist info.  It should be almost identical.