### PR TITLE
add pid tag to py.threading.active metrics

### DIFF
--- a/runmetrics/stats_collector.py
+++ b/runmetrics/stats_collector.py
@@ -51,7 +51,7 @@ class StatsCollector:
         self._ru_nivcsw = self._registry.gauge("py.resource.contextSwitches", {"id": "involuntary"})
 
         # threading metrics
-        self._threading_active = self._registry.gauge("py.threading.active")
+        self._threading_active = self._registry.gauge("py.threading.active", {"pid": f"{os.getpid()}"})
 
     def _target(self):
         self._logger.info("start collecting runtime metrics every %s seconds", self._period)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ python_requires = >3.9
 packages =
     runmetrics
 install_requires =
-    netflix-spectator-py==1.0.0rc1
+    netflix-spectator-py==1.0.0rc2
 
 [options.extras_require]
 dev =

--- a/tests/test_stats_collector.py
+++ b/tests/test_stats_collector.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest.mock
 
 from spectator.config import Config
 from spectator.registry import Registry
@@ -39,9 +39,9 @@ class MockStatsCollector(StatsCollector):
         self._threading_active.set(500)
 
 
+@unittest.mock.patch("os.getpid", return_value=1)
 class StatsCollectorTest(unittest.TestCase):
-
-    def test_collect_stats(self):
+    def test_collect_stats(self, mock_getpid):
         r = Registry(Config("memory"))
         MockStatsCollector(r).collect_stats()
         self.assertEqual(29, len(r.writer().get()))
@@ -75,6 +75,6 @@ class StatsCollectorTest(unittest.TestCase):
             'g:py.resource.blockOperations,id=output:406',
             'g:py.resource.contextSwitches,id=voluntary:407',
             'g:py.resource.contextSwitches,id=involuntary:408',
-            'g:py.threading.active:500'
+            'g:py.threading.active,pid=1:500'
         ]
         self.assertEqual(expected, r.writer().get())


### PR DESCRIPTION
This is necessary to keep accurate thread counts when process worker forking occurs. Else, the last reporting process value will be the one reported every minute.