### PR TITLE
fix tests and add pid tags

### DIFF
--- a/tests/test_stats_collector.py
+++ b/tests/test_stats_collector.py
@@ -1,4 +1,5 @@
-import unittest.mock
+from collections import namedtuple
+from unittest import mock, TestCase
 
 from spectator.config import Config
 from spectator.registry import Registry
@@ -6,75 +7,86 @@ from spectator.registry import Registry
 from runmetrics.stats_collector import StatsCollector
 
 
-class MockStatsCollector(StatsCollector):
-    def _collect_fd_stats(self):
-        self._fd_max.set(100)
+GC_GET_STATS = [
+    {'collections': 10, 'collected': 11, 'uncollectable': 12},
+    {'collections': 20, 'collected': 21, 'uncollectable': 22},
+    {'collections': 30, 'collected': 31, 'uncollectable': 32}
+]
 
-    def _collect_gc_stats(self):
-        self._gc_enabled.set(200)
+Rusage = namedtuple('Rusage', ['ru_utime', 'ru_stime', 'ru_maxrss', 'ru_minflt',
+                               'ru_majflt', 'ru_inblock', 'ru_oublock', 'ru_nvcsw', 'ru_nivcsw'])
 
-        for i in range(0, 3):
-            self._gc_gen[i]["collections"].set(201)
-            self._gc_gen[i]["collected"].set(202)
-            self._gc_gen[i]["uncollectable"].set(203)
-            self._gc_gen[i]["threshold"].set(204)
-            self._gc_gen[i]["count"].set(205)
-
-    def _collect_mp_stats(self):
-        self._mp_active_children.set(300)
-        self._mp_cpu.set(301)
-
-    def _collect_resource_stats(self):
-        self._ru_utime.set(400)
-        self._ru_stime.set(401)
-        self._ru_maxrss.set(402)
-        self._ru_minflt.set(403)
-        self._ru_majflt.set(404)
-        self._ru_inblock.set(405)
-        self._ru_oublock.set(406)
-        self._ru_nvcsw.set(407)
-        self._ru_nivcsw.set(408)
-
-    def _collect_threading_stats(self):
-        self._threading_active.set(500)
+RESOURCE_GETRUSAGE = Rusage(1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 
-@unittest.mock.patch("os.getpid", return_value=1)
-class StatsCollectorTest(unittest.TestCase):
-    def test_collect_stats(self, mock_getpid):
+@mock.patch("resource.RLIMIT_NOFILE", 2)
+@mock.patch("sys.platform", "linux")
+@mock.patch("gc.get_stats", return_value=GC_GET_STATS)
+@mock.patch("gc.get_threshold", return_value=(100, 101, 102))
+@mock.patch("gc.get_count", return_value=(200, 201, 202))
+@mock.patch("gc.isenabled", return_value=True)
+@mock.patch("multiprocessing.active_children", return_value=[])
+@mock.patch("multiprocessing.cpu_count", return_value=4)
+@mock.patch("os.getpid", return_value=7)
+@mock.patch("os.listdir", return_value=["0"])
+@mock.patch("resource.getrusage", return_value=RESOURCE_GETRUSAGE)
+@mock.patch("threading.active_count", return_value=5)
+class StatsCollectorTest(TestCase):
+    def test_collect_stats(self, gc_get_stats, gc_get_threshold, gc_get_count, gc_isenabled,
+                           mp_active_children, mp_cpu_count, os_getpid, os_listdir,
+                           resource_getrusage, threading_active_count):
         r = Registry(Config("memory"))
-        MockStatsCollector(r).collect_stats()
-        self.assertEqual(29, len(r.writer().get()))
+        StatsCollector(r).collect_stats()
 
-        expected = [
-            'g:py.fd,id=max:100',
-            'g:py.gc.enabled:200',
-            'g:py.gc.collections,gen=0:201',
-            'g:py.gc.collected,gen=0:202',
-            'g:py.gc.uncollectable,gen=0:203',
-            'g:py.gc.threshold,gen=0:204',
-            'g:py.gc.count,gen=0:205',
-            'g:py.gc.collections,gen=1:201',
-            'g:py.gc.collected,gen=1:202',
-            'g:py.gc.uncollectable,gen=1:203',
-            'g:py.gc.threshold,gen=1:204',
-            'g:py.gc.count,gen=1:205',
-            'g:py.gc.collections,gen=2:201',
-            'g:py.gc.collected,gen=2:202',
-            'g:py.gc.uncollectable,gen=2:203',
-            'g:py.gc.threshold,gen=2:204',
-            'g:py.gc.count,gen=2:205',
-            'g:py.mp.activeChildren:300',
-            'g:py.mp.cpu:301',
-            'g:py.resource.time,mode=user:400',
-            'g:py.resource.time,mode=system:401',
-            'g:py.resource.maxResidentSetSize:402',
-            'g:py.resource.pageFaults,io.required=false:403',
-            'g:py.resource.pageFaults,io.required=true:404',
-            'g:py.resource.blockOperations,id=input:405',
-            'g:py.resource.blockOperations,id=output:406',
-            'g:py.resource.contextSwitches,id=voluntary:407',
-            'g:py.resource.contextSwitches,id=involuntary:408',
-            'g:py.threading.active,pid=1:500'
+        messages = r.writer().get()
+        self.assertEqual(30, len(messages))
+
+        fd_expected = [
+            'g:py.fd,id=max,pid=7:2',
+            'g:py.fd,id=allocated,pid=7:1',
         ]
-        self.assertEqual(expected, r.writer().get())
+        self.assertEqual(fd_expected, [m for m in messages if 'py.fd' in m])
+
+        gc_expected = [
+            'g:py.gc.enabled,pid=7:1',
+            'g:py.gc.collections,gen=0,pid=7:10',
+            'g:py.gc.collected,gen=0,pid=7:11',
+            'g:py.gc.uncollectable,gen=0,pid=7:12',
+            'g:py.gc.threshold,gen=0,pid=7:100',
+            'g:py.gc.count,gen=0,pid=7:200',
+            'g:py.gc.collections,gen=1,pid=7:20',
+            'g:py.gc.collected,gen=1,pid=7:21',
+            'g:py.gc.uncollectable,gen=1,pid=7:22',
+            'g:py.gc.threshold,gen=1,pid=7:101',
+            'g:py.gc.count,gen=1,pid=7:201',
+            'g:py.gc.collections,gen=2,pid=7:30',
+            'g:py.gc.collected,gen=2,pid=7:31',
+            'g:py.gc.uncollectable,gen=2,pid=7:32',
+            'g:py.gc.threshold,gen=2,pid=7:102',
+            'g:py.gc.count,gen=2,pid=7:202',
+        ]
+        self.assertEqual(gc_expected, [m for m in messages if 'py.gc' in m])
+
+        mp_expected = [
+            'g:py.mp.activeChildren,pid=7:0',
+            'g:py.mp.cpu,pid=7:4',
+        ]
+        self.assertEqual(mp_expected, [m for m in messages if 'py.mp' in m])
+
+        resource_expected = [
+            'g:py.resource.time,mode=user,pid=7:1',
+            'g:py.resource.time,mode=system,pid=7:2',
+            'g:py.resource.maxResidentSetSize,pid=7:3',
+            'g:py.resource.pageFaults,io.required=false,pid=7:4',
+            'g:py.resource.pageFaults,io.required=true,pid=7:5',
+            'g:py.resource.blockOperations,id=input,pid=7:6',
+            'g:py.resource.blockOperations,id=output,pid=7:7',
+            'g:py.resource.contextSwitches,id=voluntary,pid=7:8',
+            'g:py.resource.contextSwitches,id=involuntary,pid=7:9',
+        ]
+        self.assertEqual(resource_expected, [m for m in messages if 'py.resource' in m])
+
+        threading_expected = [
+            'g:py.threading.active,pid=7:5'
+        ]
+        self.assertEqual(threading_expected, [m for m in messages if 'py.threading' in m])


### PR DESCRIPTION
The tests now rely on patching the key system calls that produce the data that will be recorded. This reduces duplication and allows the tests to exercise the methods in the collector.

A `pid` tag has been added to all of the metrics, because there are situations where this collector will be launched within each process in a forking model of execution.