### PR TITLE
implement feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ from runmetrics.stats_collector import StatsCollector
 
 if __name__ == "__main__":
     registry = Registry()
-    StatsCollector(registry).start()
+    # enable the `pid` tag on all metrics, if you are forking processes - default is False
+    StatsCollector(registry, enable_pid_tag=False).start()
 ```
 
 ## References
@@ -24,6 +25,7 @@ if __name__ == "__main__":
 * Python
     * [gc — Garbage Collector interface](https://docs.python.org/3/library/gc.html)
     * [multiprocessing — Process-based parallelism](https://docs.python.org/3/library/multiprocessing.html)
+    * [os — Miscellaneous operating system interfaces](https://docs.python.org/3/library/os.html)
     * [resource — Resource usage information](https://docs.python.org/3/library/resource.html)
     * [threading — Thread-based parallelism](https://docs.python.org/3/library/threading.html)
 * Linux


### PR DESCRIPTION
* Switch use of `mp.cpu_count()` to `os.cpu_count()`, which will not raise.
* Add `enabled_pid_tag` flag to the `StatsCollector.__init__()`, so that users
can choose whether or not they want a `pid` tag added to all metrics. The
default is `False`, and it can be enabled if an app forks processes.
* Add `period` flag to the `StatsCollector.__init__()`, so that users can
choose their metrics collection period, although the default 30 seconds should
be sufficient for most use cases.
* Add a `py.gc.pause` timer metric to record GC pause times, and only add the
callback for `CPython` implementations.
* Add a conditional import for `psutil` and future-proof the fd stats
collection method, if and when this library is used on MacOS or Windows.
* Set the `_enabled` flag to `True` when calling the `start` method, so that
the background collection thread can be started again, if it was ever stopped.