### PR TITLE
adjust meter types

### DIFF
--- a/runmetrics/stats_collector.py
+++ b/runmetrics/stats_collector.py
@@ -7,9 +7,10 @@ import resource
 import sys
 import threading
 import time
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from spectator.meter.gauge import Gauge
+from spectator.meter.monotonic_counter import MonotonicCounter
 from spectator.registry import Registry
 
 try:
@@ -33,12 +34,12 @@ class StatsCollector:
         # garbage collector metrics
         self._gc_enabled = self._registry.gauge("py.gc.enabled", self._with_worker_id({}))
 
-        self._gc_gen: Dict[int, Dict[str, Gauge]] = {}
+        self._gc_gen: Dict[int, Dict[str, Union[Gauge, MonotonicCounter]]] = {}
         for i in range(0, 3):
             self._gc_gen[i] = {}
-            self._gc_gen[i]["collections"] = self._registry.gauge("py.gc.collections", self._with_worker_id({"gen": f"{i}"}))
-            self._gc_gen[i]["collected"] = self._registry.gauge("py.gc.collected", self._with_worker_id({"gen": f"{i}"}))
-            self._gc_gen[i]["uncollectable"] = self._registry.gauge("py.gc.uncollectable", self._with_worker_id({"gen": f"{i}"}))
+            self._gc_gen[i]["collections"] = self._registry.monotonic_counter("py.gc.collections", self._with_worker_id({"gen": f"{i}"}))
+            self._gc_gen[i]["collected"] = self._registry.monotonic_counter("py.gc.collected", self._with_worker_id({"gen": f"{i}"}))
+            self._gc_gen[i]["uncollectable"] = self._registry.monotonic_counter("py.gc.uncollectable", self._with_worker_id({"gen": f"{i}"}))
             self._gc_gen[i]["threshold"] = self._registry.gauge("py.gc.threshold", self._with_worker_id({"gen": f"{i}"}))
             self._gc_gen[i]["count"] = self._registry.gauge("py.gc.count", self._with_worker_id({"gen": f"{i}"}))
 
@@ -53,15 +54,15 @@ class StatsCollector:
         self._os_cpu = self._registry.gauge("py.os.cpu", self._with_worker_id({}))
 
         # resource usage metrics
-        self._ru_utime = self._registry.gauge("py.resource.time", self._with_worker_id({"mode": "user"}))
-        self._ru_stime = self._registry.gauge("py.resource.time", self._with_worker_id({"mode": "system"}))
+        self._ru_utime = self._registry.monotonic_counter("py.resource.time", self._with_worker_id({"mode": "user"}))
+        self._ru_stime = self._registry.monotonic_counter("py.resource.time", self._with_worker_id({"mode": "system"}))
         self._ru_maxrss = self._registry.gauge("py.resource.maxResidentSetSize", self._with_worker_id({}))
-        self._ru_minflt = self._registry.gauge("py.resource.pageFaults", self._with_worker_id({"io.required": "false"}))
-        self._ru_majflt = self._registry.gauge("py.resource.pageFaults", self._with_worker_id({"io.required": "true"}))
-        self._ru_inblock = self._registry.gauge("py.resource.blockOperations", self._with_worker_id({"id": "input"}))
-        self._ru_oublock = self._registry.gauge("py.resource.blockOperations", self._with_worker_id({"id": "output"}))
-        self._ru_nvcsw = self._registry.gauge("py.resource.contextSwitches", self._with_worker_id({"id": "voluntary"}))
-        self._ru_nivcsw = self._registry.gauge("py.resource.contextSwitches", self._with_worker_id({"id": "involuntary"}))
+        self._ru_minflt = self._registry.monotonic_counter("py.resource.pageFaults", self._with_worker_id({"io.required": "false"}))
+        self._ru_majflt = self._registry.monotonic_counter("py.resource.pageFaults", self._with_worker_id({"io.required": "true"}))
+        self._ru_inblock = self._registry.monotonic_counter("py.resource.blockOperations", self._with_worker_id({"id": "input"}))
+        self._ru_oublock = self._registry.monotonic_counter("py.resource.blockOperations", self._with_worker_id({"id": "output"}))
+        self._ru_nvcsw = self._registry.monotonic_counter("py.resource.contextSwitches", self._with_worker_id({"id": "voluntary"}))
+        self._ru_nivcsw = self._registry.monotonic_counter("py.resource.contextSwitches", self._with_worker_id({"id": "involuntary"}))
 
         # threading metrics
         self._threading_active = self._registry.gauge("py.threading.active", self._with_worker_id({}))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = netflix-spectator-py-runtime-metrics
-version = 1.0.3
+version = 1.0.4
 description = Library to collect runtime metrics for Python applications using spectator-py.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_stats_collector.py
+++ b/tests/test_stats_collector.py
@@ -48,19 +48,19 @@ class StatsCollectorTest(TestCase):
 
         gc_expected = [
             'g:py.gc.enabled,worker.id=7:1',
-            'g:py.gc.collections,gen=0,worker.id=7:10',
-            'g:py.gc.collected,gen=0,worker.id=7:11',
-            'g:py.gc.uncollectable,gen=0,worker.id=7:12',
+            'C:py.gc.collections,gen=0,worker.id=7:10',
+            'C:py.gc.collected,gen=0,worker.id=7:11',
+            'C:py.gc.uncollectable,gen=0,worker.id=7:12',
             'g:py.gc.threshold,gen=0,worker.id=7:100',
             'g:py.gc.count,gen=0,worker.id=7:200',
-            'g:py.gc.collections,gen=1,worker.id=7:20',
-            'g:py.gc.collected,gen=1,worker.id=7:21',
-            'g:py.gc.uncollectable,gen=1,worker.id=7:22',
+            'C:py.gc.collections,gen=1,worker.id=7:20',
+            'C:py.gc.collected,gen=1,worker.id=7:21',
+            'C:py.gc.uncollectable,gen=1,worker.id=7:22',
             'g:py.gc.threshold,gen=1,worker.id=7:101',
             'g:py.gc.count,gen=1,worker.id=7:201',
-            'g:py.gc.collections,gen=2,worker.id=7:30',
-            'g:py.gc.collected,gen=2,worker.id=7:31',
-            'g:py.gc.uncollectable,gen=2,worker.id=7:32',
+            'C:py.gc.collections,gen=2,worker.id=7:30',
+            'C:py.gc.collected,gen=2,worker.id=7:31',
+            'C:py.gc.uncollectable,gen=2,worker.id=7:32',
             'g:py.gc.threshold,gen=2,worker.id=7:102',
             'g:py.gc.count,gen=2,worker.id=7:202',
         ]
@@ -73,15 +73,15 @@ class StatsCollectorTest(TestCase):
         self.assertEqual(mp_expected, [m for m in messages if 'py.mp' in m or 'py.os' in m])
 
         resource_expected = [
-            'g:py.resource.time,mode=user,worker.id=7:1',
-            'g:py.resource.time,mode=system,worker.id=7:2',
+            'C:py.resource.time,mode=user,worker.id=7:1',
+            'C:py.resource.time,mode=system,worker.id=7:2',
             'g:py.resource.maxResidentSetSize,worker.id=7:3',
-            'g:py.resource.pageFaults,io.required=false,worker.id=7:4',
-            'g:py.resource.pageFaults,io.required=true,worker.id=7:5',
-            'g:py.resource.blockOperations,id=input,worker.id=7:6',
-            'g:py.resource.blockOperations,id=output,worker.id=7:7',
-            'g:py.resource.contextSwitches,id=voluntary,worker.id=7:8',
-            'g:py.resource.contextSwitches,id=involuntary,worker.id=7:9',
+            'C:py.resource.pageFaults,io.required=false,worker.id=7:4',
+            'C:py.resource.pageFaults,io.required=true,worker.id=7:5',
+            'C:py.resource.blockOperations,id=input,worker.id=7:6',
+            'C:py.resource.blockOperations,id=output,worker.id=7:7',
+            'C:py.resource.contextSwitches,id=voluntary,worker.id=7:8',
+            'C:py.resource.contextSwitches,id=involuntary,worker.id=7:9',
         ]
         self.assertEqual(resource_expected, [m for m in messages if 'py.resource' in m])
 
@@ -108,19 +108,19 @@ class StatsCollectorTest(TestCase):
 
         gc_expected = [
             'g:py.gc.enabled:1',
-            'g:py.gc.collections,gen=0:10',
-            'g:py.gc.collected,gen=0:11',
-            'g:py.gc.uncollectable,gen=0:12',
+            'C:py.gc.collections,gen=0:10',
+            'C:py.gc.collected,gen=0:11',
+            'C:py.gc.uncollectable,gen=0:12',
             'g:py.gc.threshold,gen=0:100',
             'g:py.gc.count,gen=0:200',
-            'g:py.gc.collections,gen=1:20',
-            'g:py.gc.collected,gen=1:21',
-            'g:py.gc.uncollectable,gen=1:22',
+            'C:py.gc.collections,gen=1:20',
+            'C:py.gc.collected,gen=1:21',
+            'C:py.gc.uncollectable,gen=1:22',
             'g:py.gc.threshold,gen=1:101',
             'g:py.gc.count,gen=1:201',
-            'g:py.gc.collections,gen=2:30',
-            'g:py.gc.collected,gen=2:31',
-            'g:py.gc.uncollectable,gen=2:32',
+            'C:py.gc.collections,gen=2:30',
+            'C:py.gc.collected,gen=2:31',
+            'C:py.gc.uncollectable,gen=2:32',
             'g:py.gc.threshold,gen=2:102',
             'g:py.gc.count,gen=2:202',
         ]
@@ -133,15 +133,15 @@ class StatsCollectorTest(TestCase):
         self.assertEqual(mp_expected, [m for m in messages if 'py.mp' in m or 'py.os' in m])
 
         resource_expected = [
-            'g:py.resource.time,mode=user:1',
-            'g:py.resource.time,mode=system:2',
+            'C:py.resource.time,mode=user:1',
+            'C:py.resource.time,mode=system:2',
             'g:py.resource.maxResidentSetSize:3',
-            'g:py.resource.pageFaults,io.required=false:4',
-            'g:py.resource.pageFaults,io.required=true:5',
-            'g:py.resource.blockOperations,id=input:6',
-            'g:py.resource.blockOperations,id=output:7',
-            'g:py.resource.contextSwitches,id=voluntary:8',
-            'g:py.resource.contextSwitches,id=involuntary:9',
+            'C:py.resource.pageFaults,io.required=false:4',
+            'C:py.resource.pageFaults,io.required=true:5',
+            'C:py.resource.blockOperations,id=input:6',
+            'C:py.resource.blockOperations,id=output:7',
+            'C:py.resource.contextSwitches,id=voluntary:8',
+            'C:py.resource.contextSwitches,id=involuntary:9',
         ]
         self.assertEqual(resource_expected, [m for m in messages if 'py.resource' in m])
 


### PR DESCRIPTION
After reviewing these metrics from live instances, some of these values are better modeled as Monotonic Counters, rather than Gauges.